### PR TITLE
Fix durability and recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /publish
 /.regolith
 deploy_originspe.sh
+build.sh
 
 /.vscode
 node_modules/
@@ -12,3 +13,4 @@ node_modules/
 *.aseprj
 *.mcworld
 *.mcpack
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build
 /publish
 /.regolith
+deploy_originspe.sh
 
 /.vscode
 node_modules/

--- a/.regolithignore
+++ b/.regolithignore
@@ -1,0 +1,2 @@
+.DS_Store
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ This repository is intended for developers and modders, if you'd like to downloa
 ## Building
 
 Execute `regolith run` in the root directory of the project to build the project. It is recommended to build the project.
+
+## Updates
+This branch fixes an issue where normal tools wouldn't show up in quick craft recipes. Also fixes an issue where tools made by the blacksmith class would never wear out or break.

--- a/README.md
+++ b/README.md
@@ -26,4 +26,8 @@ This repository is intended for developers and modders, if you'd like to downloa
 Execute `regolith run` in the root directory of the project to build the project. It is recommended to build the project.
 
 ## Updates
-This branch fixes an issue where normal tools wouldn't show up in quick craft recipes. Also fixes an issue where tools made by the blacksmith class would never wear out or break.
+
+- This branch fixes an issue where normal tools wouldn't show up in quick craft recipes. 
+- Fixes an issue where tools made by the blacksmith class would never wear out or break.
+- Fixes bug where blacksmith could convert tools from other players into Quality Equiptment simply by placing it in their inventory.
+- Fixes issue where Enderian origin could teleport outside of their render distance causing errors and spontoneous teleportation when the chunk loaded.

--- a/config.json
+++ b/config.json
@@ -56,7 +56,10 @@
 						"settings": {
 							"output": "OriginsPE-${git.tag ?? 'test'}${git.tagCommit !== git.commit ? '-' + git.commit.substr(0, 6) : ''}.mcworld",
 							"worldName": "OriginsPE-${git.tag ?? 'test'}",
-							"worldPath": "../../world"
+							"worldPath": "../../world",
+							"exclude": [
+					      "**/.DS_Store"
+					    ]
 						}
 					}
 				]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "OriginsPE",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/packs/BP/recipes/blacksmith/non_smithing.blacksmith.templ
+++ b/packs/BP/recipes/blacksmith/non_smithing.blacksmith.templ
@@ -62,7 +62,7 @@
 
     "minecraft:recipe_shaped": {
       "result": {
-        "item": "r4isen1920_originspe:temp_{{fileBaseName(value)}}"
+        "item": "minecraft:{{fileBaseName(value)}}"
       }
     }
 

--- a/packs/data/gametests/src/data/classes/perks/quality_equipment.js
+++ b/packs/data/gametests/src/data/classes/perks/quality_equipment.js
@@ -5,6 +5,7 @@ import { toAllPlayers } from "../../../origins/player";
 import { findItems } from "../../../utils/items";
 
 const is_blacksmith_class_item = "r4isen1920_originspe:blacksmith_"
+const is_quality_set_property = 'is_quality_set'
 
 /**
  * 
@@ -56,11 +57,11 @@ const items = [
  * @param { import('@minecraft/server').Player } player 
  */
 function quality_equipment(player) {
-  const foodItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId) && !item?.item?.getDynamicProperty('maker_set'))
+  const unsetBlacksmithItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId) && !item?.item?.getDynamicProperty(is_quality_set_property))
 
-  if (foodItemsInInventory.length === 0) return;
+  if (unsetBlacksmithItemsInInventory.length === 0) return;
 
-  for (const item of foodItemsInInventory) {
+  for (const item of unsetBlacksmithItemsInInventory) {
     const baseTypeId = item.item.typeId.replace('minecraft:', '');
     const newItemTypeId = player.hasTag('class_blacksmith') ? `r4isen1920_originspe:blacksmith_${baseTypeId}` : `minecraft:${baseTypeId}`;
     const newItem = new ItemStack(newItemTypeId, item.item.amount);
@@ -72,7 +73,7 @@ function quality_equipment(player) {
     newItem.setLore(setLore);
 
     // If this property is not set, tools made by non-blacksmith players may be converted to Quality Equiptment when it enters a blacksmith's inventory
-    newItem.setDynamicProperty('maker_set', true)
+    newItem.setDynamicProperty(is_quality_set_property, true)
 
     player.getComponent('inventory').container.setItem(item.slot, newItem);
 

--- a/packs/data/gametests/src/data/classes/perks/quality_equipment.js
+++ b/packs/data/gametests/src/data/classes/perks/quality_equipment.js
@@ -57,11 +57,11 @@ const items = [
  * @param { import('@minecraft/server').Player } player 
  */
 function quality_equipment(player) {
-  const unsetBlacksmithItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId) && !item?.item?.getDynamicProperty(is_quality_set_property))
+  const unsetItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId) && !item?.item?.getDynamicProperty(is_quality_set_property))
 
-  if (unsetBlacksmithItemsInInventory.length === 0) return;
+  if (unsetItemsInInventory.length === 0) return;
 
-  for (const item of unsetBlacksmithItemsInInventory) {
+  for (const item of unsetItemsInInventory) {
     const baseTypeId = item.item.typeId.replace('minecraft:', '');
     const newItemTypeId = player.hasTag('class_blacksmith') ? `r4isen1920_originspe:blacksmith_${baseTypeId}` : `minecraft:${baseTypeId}`;
     const newItem = new ItemStack(newItemTypeId, item.item.amount);

--- a/packs/data/gametests/src/data/classes/perks/quality_equipment.js
+++ b/packs/data/gametests/src/data/classes/perks/quality_equipment.js
@@ -56,7 +56,8 @@ const items = [
  * @param { import('@minecraft/server').Player } player 
  */
 function quality_equipment(player) {
-  const foodItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId))
+  const foodItemsInInventory = findItems(player).filter(item => items.includes(item?.item?.typeId) && !item?.item?.getDynamicProperty('maker_set'))
+
   if (foodItemsInInventory.length === 0) return;
 
   for (const item of foodItemsInInventory) {
@@ -70,7 +71,11 @@ function quality_equipment(player) {
     if (player.hasTag('class_blacksmith')) setLore.push('§r§6Quality Equipment§r');
     newItem.setLore(setLore);
 
+    // If this property is not set, tools made by non-blacksmith players may be converted to Quality Equiptment when it enters a blacksmith's inventory
+    newItem.setDynamicProperty('maker_set', true)
+
     player.getComponent('inventory').container.setItem(item.slot, newItem);
+
   }
   if (player.hasTag('class_blacksmith')) player.playSound('smithing_table.use', { volume: 0.75, pitch: 1.25 })
 

--- a/packs/data/gametests/src/data/origins/powers/elytra.js
+++ b/packs/data/gametests/src/data/origins/powers/elytra.js
@@ -17,7 +17,7 @@ function elytra(player) {
        * @type { string[] }
        */
       const lore = playerEquipment.getEquipment(EquipmentSlot.Chest)?.getLore()
-      if (!lore.includes('§r§6Elytrian§r')) return
+      if (!lore?.includes('§r§6Elytrian§r')) return
       playerEquipment.setEquipment(EquipmentSlot.Chest, undefined)
     }
 

--- a/packs/data/gametests/src/data/origins/powers/elytra.js
+++ b/packs/data/gametests/src/data/origins/powers/elytra.js
@@ -1,36 +1,53 @@
-
-import { EquipmentSlot, ItemLockMode, ItemStack } from "@minecraft/server";
-
+import {
+  EquipmentSlot,
+  ItemLockMode,
+  ItemStack,
+  ItemComponentTypes,
+  TicksPerSecond,
+} from "@minecraft/server";
 import { toAllPlayers } from "../../../origins/player";
 
 /**
- * 
- * @param { import('@minecraft/server').Player } player 
+ * Equips or removes an Elytra with custom lore and keeps it repaired.
+ * @param {import('@minecraft/server').Player} player
  */
 function elytra(player) {
+  const equipment = player.getComponent("equippable");
 
-  if (!player.hasTag('power_elytra')) {
+  if (!equipment) return;
 
-    const playerEquipment = player.getComponent('equippable');
-    if (playerEquipment) {
-      /**
-       * @type { string[] }
-       */
-      const lore = playerEquipment.getEquipment(EquipmentSlot.Chest)?.getLore()
-      if (!lore?.includes('§r§6Elytrian§r')) return
-      playerEquipment.setEquipment(EquipmentSlot.Chest, undefined)
+  const chestItem = equipment.getEquipment(EquipmentSlot.Chest);
+  const hasElytraPower = player.hasTag("power_elytra");
+  const isCustomElytra = chestItem?.getLore()?.includes("§r§6Elytrian§r");
+
+  if (!hasElytraPower) {
+    // Remove Elytra if equipped and it matches the custom one
+    if (isCustomElytra) {
+      equipment.setEquipment(EquipmentSlot.Chest, undefined);
     }
-
-    return
+    return;
   }
 
-  if (player.getComponent('equippable').getEquipment(EquipmentSlot.Chest)?.typeId === 'minecraft:elytra') return
+  if (isCustomElytra) {
+    // 🔁 Reset durability if custom elytra is already equipped
+    const durability = chestItem.getComponent(ItemComponentTypes.Durability);
+    if (durability && durability.damage > 0) {
+      durability.damage = 0;
+      equipment.setEquipment(EquipmentSlot.Chest, chestItem);
+    }
+    return;
+  }
 
-  const newElytra = new ItemStack('minecraft:elytra')
-  newElytra.lockMode = ItemLockMode.slot
-  newElytra.setLore(['§r§6Elytrian§r'])
+  // 🎯 Equip new Elytra if not present
+  const newElytra = new ItemStack("minecraft:elytra");
+  newElytra.lockMode = ItemLockMode.slot;
+  newElytra.keepOnDeath = true;
+  newElytra.setLore(["§r§6Elytrian§r"]);
 
-  player.getComponent('equippable').setEquipment(EquipmentSlot.Chest, newElytra)
+  const durability = newElytra.getComponent(ItemComponentTypes.Durability);
+  if (durability) durability.damage = 0;
+
+  equipment.setEquipment(EquipmentSlot.Chest, newElytra);
 }
 
-toAllPlayers(elytra, 5)
+toAllPlayers(elytra, TicksPerSecond * 5);

--- a/packs/data/gametests/src/data/origins/powers/phantomize.js
+++ b/packs/data/gametests/src/data/origins/powers/phantomize.js
@@ -1,5 +1,5 @@
 
-import { world } from "@minecraft/server";
+import { world, GameMode } from "@minecraft/server";
 
 import { toAllPlayers } from "../../../origins/player";
 import { ResourceBar } from "../../../origins/resource_bar";
@@ -9,7 +9,10 @@ import { ResourceBar } from "../../../origins/resource_bar";
  * @param { import('@minecraft/server').Player } player 
  */
 function phantomize(player) {
-  if (!player.hasTag('power_phantomize')) return;
+
+  const started_in_spectator_mode = player.getDynamicProperty('starting_gamemode') === GameMode.spectator;
+
+  if (!player.hasTag('power_phantomize') && !started_in_spectator_mode) return;
 
   if (player.hasTag('_control_use_phantomize')) {
 
@@ -31,7 +34,7 @@ function phantomize(player) {
 
   const cooldown = new ResourceBar(5, 100, 0, 2)
 
-  if (player.hasTag('_phantomized')) {
+  if (player.hasTag('_phantomized') || started_in_spectator_mode) {
 
     const isPlayerMoving = player.getVelocity().x !== 0 || player.getVelocity().y !== 0 || player.getVelocity().z !== 0;
 
@@ -96,5 +99,5 @@ function exitPhantomizedForm(player) {
   player.removeTag('_phantomized');
   player.removeTag('_control_use_phantomize');
   player.setDynamicProperty('r4isen1920_originspe:move_ticks', 0)
-
+  player.setDynamicProperty("starting_gamemode", player.getGameMode());
 }

--- a/packs/data/gametests/src/data/origins/powers/phantomize.js
+++ b/packs/data/gametests/src/data/origins/powers/phantomize.js
@@ -1,5 +1,5 @@
 
-import { world, GameMode } from "@minecraft/server";
+import { world } from "@minecraft/server";
 
 import { toAllPlayers } from "../../../origins/player";
 import { ResourceBar } from "../../../origins/resource_bar";
@@ -10,9 +10,7 @@ import { ResourceBar } from "../../../origins/resource_bar";
  */
 function phantomize(player) {
 
-  const started_in_spectator_mode = player.getDynamicProperty('starting_gamemode') === GameMode.spectator;
-
-  if (!player.hasTag('power_phantomize') && !started_in_spectator_mode) return;
+  if (!player.hasTag('power_phantomize')) return;
 
   if (player.hasTag('_control_use_phantomize')) {
 
@@ -34,7 +32,7 @@ function phantomize(player) {
 
   const cooldown = new ResourceBar(5, 100, 0, 2)
 
-  if (player.hasTag('_phantomized') || started_in_spectator_mode) {
+  if (player.hasTag('_phantomized')) {
 
     const isPlayerMoving = player.getVelocity().x !== 0 || player.getVelocity().y !== 0 || player.getVelocity().z !== 0;
 
@@ -99,5 +97,4 @@ function exitPhantomizedForm(player) {
   player.removeTag('_phantomized');
   player.removeTag('_control_use_phantomize');
   player.setDynamicProperty('r4isen1920_originspe:move_ticks', 0)
-  player.setDynamicProperty("starting_gamemode", player.getGameMode());
 }

--- a/packs/data/gametests/src/data/origins/powers/throw_ender_pearl.js
+++ b/packs/data/gametests/src/data/origins/powers/throw_ender_pearl.js
@@ -4,6 +4,9 @@ import { Direction, world } from "@minecraft/server";
 import { toAllPlayers } from "../../../origins/player";
 import { ResourceBar } from "../../../origins/resource_bar";
 
+const blocksPerChunk = 16;
+const safeMaxRenderChunks = 12;
+
 /**
  * 
  * @param { import('@minecraft/server').Player } player 
@@ -14,10 +17,17 @@ function throw_ender_pearl(player) {
     !player.hasTag('_control_use_throw_ender_pearl')
   ) return
 
+  const playerMaxRenderChunks = player.clientSystemInfo.maxRenderDistance;
+
+  const maxRenderDistance = Math.min(playerMaxRenderChunks, safeMaxRenderChunks) * blocksPerChunk;
 
   if (!player.hasTag('cooldown_3')) {
 
-    const targetBlock = player.getBlockFromViewDirection()
+    const targetBlock = player.getBlockFromViewDirection({ 
+      maxDistance: MAX_TELEPORT_DISTANCE, 
+      includeLiquidBlocks: false 
+    });
+
     if (!targetBlock) {
       player.removeTag('_control_use_throw_ender_pearl');
       player.playSound('note.bass', { volume: 1, pitch: 1.5 });

--- a/packs/data/gametests/src/origins/init.js
+++ b/packs/data/gametests/src/origins/init.js
@@ -63,6 +63,8 @@ world.afterEvents.playerSpawn.subscribe(
       player.addTag('has_any_race');
       player.addTag('has_any_class');
     }
+
+    player.setDynamicProperty("starting_gamemode", player.getGameMode());
   }
 )
 

--- a/packs/data/gametests/src/origins/init.js
+++ b/packs/data/gametests/src/origins/init.js
@@ -63,8 +63,6 @@ world.afterEvents.playerSpawn.subscribe(
       player.addTag('has_any_race');
       player.addTag('has_any_class');
     }
-
-    player.setDynamicProperty("starting_gamemode", player.getGameMode());
   }
 )
 

--- a/packs/data/gametests/src/origins/player.js
+++ b/packs/data/gametests/src/origins/player.js
@@ -1,5 +1,5 @@
 
-import { world, system } from "@minecraft/server";
+import { world, system, GameMode } from "@minecraft/server";
 
 import { openScreenPickerGUI, setupMenuItem } from "./gui.js";
 import { removeTags } from "../utils/tags.js";
@@ -193,6 +193,9 @@ export async function initModules(player) {
 
   setupMenuItem(player);
 
+  if(player.hasTag('power_phantomize') && player.getGameMode() === GameMode.spectator) {
+    player.addTag('_phantomized');
+  }
 }
 
 


### PR DESCRIPTION
1. Fixes issue where items crafted by non-blacksmith classes could be converted into Quality Items if they entered a blacksmith class's inventory.

2. Fixes issue where blacksmith tools (pickaxe, axe, shovel, etc...) would not show up in recipes preventing mobile players from quick crafting them.

3. Fixes issue where blacksmith Quality tools would never wear out or break.

4. Fixes issue where Enderian origin could teleport outside of their render distance causing errors and spontaneous teleportation when the chunk loaded.

![Missing recipes](https://github.com/user-attachments/assets/d2ececbf-cd6e-4591-95a4-0b7168455105)