### PR TITLE
Zeus: prune expired cooldown entries to bound map growth

### DIFF
--- a/packs/data/gametests/src/domain/powers/ElectricAura.ts
+++ b/packs/data/gametests/src/domain/powers/ElectricAura.ts
@@ -23,6 +23,15 @@ export class ElectricAura implements Power {
 
         const now = system.currentTick;
 
+        // Drop expired cooldown entries so the map doesn't grow unbounded as
+        // mobs spawn and despawn. An expired entry no longer suppresses a hit,
+        // so removing it is behaviour-preserving. Swept once per cooldown span.
+        if (now % TARGET_COOLDOWN_TICKS === 0) {
+            for (const [id, tick] of targetCooldowns) {
+                if (now >= tick) targetCooldowns.delete(id);
+            }
+        }
+
         player.dimension.spawnParticle(
             'r4isen1920_originspe:electric_aura',
             player.location

--- a/packs/data/gametests/src/domain/powers/StaticField.ts
+++ b/packs/data/gametests/src/domain/powers/StaticField.ts
@@ -6,8 +6,10 @@ import { PlayerState } from '../../core/platform/PlayerState';
 const RETALIATION_DAMAGE = 2; // 1 full heart
 const KNOCKBACK_STRENGTH = 0.5;
 const RECOIL_COOLDOWN_TICKS = 10; // 0.5 seconds
+const PRUNE_INTERVAL_TICKS = 200; // sweep expired entries at most this often
 
 const attackerCooldowns = new Map<string, number>();
+let lastPruneTick = 0;
 
 world.afterEvents.entityHurt.subscribe((event) => {
     const victim = event.hurtEntity;
@@ -19,6 +21,17 @@ world.afterEvents.entityHurt.subscribe((event) => {
     if (!PlayerState.for(victim).hasPower('static_field')) return;
 
     const now = system.currentTick;
+
+    // Periodically drop expired cooldown entries so the map doesn't grow
+    // unbounded across every attacker ever seen. Gated by wall-clock ticks
+    // since this runs from a sporadic combat event, not a fixed tick loop.
+    if (now - lastPruneTick >= PRUNE_INTERVAL_TICKS) {
+        lastPruneTick = now;
+        for (const [id, tick] of attackerCooldowns) {
+            if (now >= tick) attackerCooldowns.delete(id);
+        }
+    }
+
     const nextValidHit = attackerCooldowns.get(attacker.id) ?? 0;
     if (now < nextValidHit) return;
 


### PR DESCRIPTION
ElectricAura's targetCooldowns and StaticField's attackerCooldowns are module-level maps keyed by arbitrary entity/attacker ids and were never cleaned up, so entries accumulated for every mob ever encountered.

Sweep expired entries (now >= tick) opportunistically: ElectricAura on a 120-tick cadence inside its per-tick loop, StaticField via a lastPruneTick gate since it runs from the sporadic entityHurt event. Removing an expired entry is behaviour-preserving (a missing key falls back to "not on cooldown").