### PR TITLE
Zeus: fix LightningSlowness losing its 50% slow after a class change

### DIFF
--- a/packs/data/gametests/src/domain/powers/LightningSlowness.ts
+++ b/packs/data/gametests/src/domain/powers/LightningSlowness.ts
@@ -1,34 +1,28 @@
 import { Player } from '@minecraft/server';
 import { Power } from '../../core/abilities/Ability';
 import { RegisterPower } from '../../core/abilities/Registries';
-import { PlayerState } from '../../core/platform/PlayerState';
 import { AttributeService } from '../../services/AttributeService';
+
+/** Baseline walking speed, matching {@link DEFAULT_ATTRIBUTES}. */
+const DEFAULT_MOVEMENT = 0.1;
+/** Half of {@link DEFAULT_MOVEMENT} — the documented 50% slowdown. */
+const SLOWED_MOVEMENT = 0.05;
 
 @RegisterPower
 export class LightningSlowness implements Power {
     readonly id = 'lightning_slowness';
     readonly tickInterval = 3;
 
-    onRelease(player: Player): void {
-        const state = PlayerState.for(player);
-        if (state.getFlag<boolean>('slow_set') === true) {
-            AttributeService.apply(player, { movement: 0.1 });
-            state.setFlag('slow_set', false);
-        }
+    onTick(player: Player): void {
+        // Re-assert the debuff every tick instead of trusting a cached flag.
+        // AttributeService diffs internally, so this only fires an entity event
+        // when the value actually changed — notably after an origin/class change
+        // force-reapplies the base movement speed, which a flag-based guard would
+        // miss, leaving the player permanently un-slowed.
+        AttributeService.apply(player, { movement: SLOWED_MOVEMENT });
     }
 
-    onTick(player: Player): void {
-        const state = PlayerState.for(player);
-        
-        if (!state.hasPower('lightning_slowness')) {
-            this.onRelease(player);
-            return;
-        }
-
-        const wasSlowApplied = state.getFlag<boolean>('slow_set') === true;
-        if (wasSlowApplied) return;
-
-        AttributeService.apply(player, { movement: 0.05 });
-        state.setFlag('slow_set', true);
+    onRelease(player: Player): void {
+        AttributeService.apply(player, { movement: DEFAULT_MOVEMENT });
     }
 }


### PR DESCRIPTION
LightningSlowness tracked whether the debuff was applied in a private `slow_set` flag and skipped re-applying when the flag was set. But PlayerLifecycle.applyOriginAndClass force-reapplies the base attribute profile (movement 0.1) on any origin/class change, without removing the power or clearing the flag. A Zeus player who changed only their class was left at 0.1 movement with slow_set still true, so onTick returned early forever and the documented 50% slowdown was permanently lost.

Drop the flag and re-assert movement: 0.05 every tick. AttributeService diffs internally, so this only fires an entity event when the value actually changed, and it now recovers after a force-reapply. onRelease restores the 0.1 baseline when the power is revoked.